### PR TITLE
Adds a configurable keyserver for APT, because we were having problem…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ## Basic ClickHouse configuration settings
 ## See more information about every setting in the config template
+clickhouse_key_server: pgpkeys.co.uk
 clickhouse_listen_host: 127.0.0.1
 clickhouse_http_port: 8123
 clickhouse_tcp_port: 9000

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add the APT Key for ClickHouse.
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: "{{ clickhouse_key_server }}"
     id: E0C56BD4
     state: present
 


### PR DESCRIPTION
…s with ip6 and the default Ubuntu keyserver in one of the Clickhouse proudction machines.