### PR TITLE
Revert "INFRUN-462: adds the dd-agent user to clickhouse group"

### DIFF
--- a/molecule/install_clickhouse/prepare.yml
+++ b/molecule/install_clickhouse/prepare.yml
@@ -1,10 +1,3 @@
 ---
 - name: Prepare to test install_clickhouse (nothing to do)
   hosts: all
-  tasks:
-    - name: Create dd-agent to emulate Datadog Agent user.
-      user:
-        name: dd-agent
-        comment: Emulated Datadog Agent user.
-        shell: /bin/false
-        home: /tmp/

--- a/molecule/install_clickhouse/verify/base.yml
+++ b/molecule/install_clickhouse/verify/base.yml
@@ -11,14 +11,3 @@
   assert:
     that:
       - "'Active: ' in service_status.stdout"
-
-- name: Get groups for dd-agent user.
-  command: groups dd-agent
-  register: dd_agent_groups
-  changed_when: no
-
-- name: Verify dd-agent is in clickhouse group.
-  assert:
-    that:
-      - "dd_agent_groups.rc == 0"
-      - "'clickhouse' in dd_agent_groups.stdout"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,9 +50,3 @@
     - "{{ clickhouse_access_control_path }}"
     - "{{ clickhouse_tmp_path }}"
     - "{{ clickhouse_log_directory }}"
-
-- name: Add the Datadog Agent user to the clickhouse group so it can read the logs
-  user:
-    name: dd-agent
-    groups: "{{ clickhouse_group }}"
-    append: yes


### PR DESCRIPTION
Datadog playbook has an option for it, which we will use instead of manually adding the user to the group.